### PR TITLE
Add method to remove teams from SCA workspace

### DIFF
--- a/veracode_api_py/api.py
+++ b/veracode_api_py/api.py
@@ -296,6 +296,9 @@ class VeracodeAPI:
     def add_workspace_team(self, workspace_guid: UUID, team_id: UUID):
         return Workspaces().add_team(workspace_guid, team_id)
 
+    def remove_workspace_team(self, workspace_guid: UUID, team_id: UUID):
+        return Workspaces().remove_team(workspace_guid, team_id)
+        
     def get_workspace_teams(self, workspace_guid: UUID=None):
         return Workspaces().get_teams(workspace_guid=workspace_guid)
 

--- a/veracode_api_py/sca.py
+++ b/veracode_api_py/sca.py
@@ -31,6 +31,9 @@ class Workspaces():
      def add_team(self,workspace_guid: UUID,team_id: UUID):
           return APIHelper()._rest_request(self.sca_base_url + "/{}/teams/{}".format(workspace_guid,team_id),"PUT")
 
+     def remove_team(self,workspace_guid: UUID,team_id: UUID):
+          return APIHelper()._rest_request(self.sca_base_url + "/{}/teams/{}".format(workspace_guid,team_id),"DELETE")
+
      def delete(self,workspace_guid: UUID):
           return APIHelper()._rest_request(self.sca_base_url + "/{}".format(workspace_guid),"DELETE") 
 


### PR DESCRIPTION
Fixes https://github.com/veracode/veracode-api-py/issues/43

I called it "remove" because it's not truly deleting the team, just detaching. Also the swagger doc said remove
https://app.swaggerhub.com/apis/Veracode/veracode-sca_agent_api_specification/3.0#/workspaces/deleteTeamUsingDELETE
