### PR TITLE
Fixed if parameter was None method would crash

### DIFF
--- a/veracode_api_py/dynamic.py
+++ b/veracode_api_py/dynamic.py
@@ -302,7 +302,8 @@ class DynUtils():
    def setup_scan(self, scan_config_request, scan_contact_info=None, linked_app_guid: UUID=None):
       payload = {}
       payload.update( scan_config_request )
-      payload.update(scan_contact_info)
+      if scan_contact_info != None:
+         payload.update(scan_contact_info)
       if linked_app_guid != None:
          payload.update({'linked_platform_app_uuid': linked_app_guid})
       return payload


### PR DESCRIPTION
For the method:
setup_scan(self, scan_config_request, scan_contact_info=None, linked_app_guid: UUID=None):

If scan_contact_info was null the "payload.update(scan_contact_info)" call would fail as non-Iterable. 

Added check to see if parameter was None.