### PR TITLE
Add support for Reporting API Scans report

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -17,6 +17,10 @@ The following methods call Veracode REST APIs and return JSON.
   - `application_id`: optional, application ID for which to return results
   - `rawjson`: optional, defaults to False. Returns full response if True, the GUID of the request if false
 
-- `Analytics().get(guid)`: check the status of the report request and return the report contents when ready. Note that this method returns a tuple of `status` (string) and `results` (list); when `status` is `COMPLETED`, the `results` list will populate with results.
+- `Analytics().get(guid, report_type(findings))`: check the status of the report request and return the report contents when ready. Note that this method returns a tuple of `status` (string) and `results` (list); when `status` is `COMPLETED`, the `results` list will populate with results. Also, you need to specify the type of data expected by the GUID with `report_type`; this defaults to `findings`.
+
+- `Analytics().get_findings(guid)`: check the status of a findings report request specified by `guid` and return the report contents when ready. Note that this method returns a tuple of `status` (string) and `results` (list); when `status` is `COMPLETED`, the `results` list will populate with results. 
+
+- `Analytics().get_scans(guid)`: check the status of a scans report request specified by `guid` and return the report contents when ready. Note that this method returns a tuple of `status` (string) and `results` (list); when `status` is `COMPLETED`, the `results` list will populate with results. 
 
 [All docs](docs.md)

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -7,12 +7,12 @@ The following methods call Veracode REST APIs and return JSON.
 1. The Reporting API is available to Veracode customers by request. More information about the API is available in the [Veracode Docs](https://docs.veracode.com/r/Reporting_REST_API).
 
 - `Analytics().create_report(report_type ('findings'),last_updated_start_date, last_updated_end_date (opt), scan_type (opt), finding_status(opt), passed_policy(opt), policy_sandbox(opt), application_id(opt), rawjson(opt))`: set up a request for a report. By default this command returns the GUID of the report request; specify `rawjson=True` to get the full response. Dates should be specified as `YYYY-MM-DD HH:MM:SS` with the timestamp optional. Options include:
-  - `report_type`: required, currently only supports `findings`
+  - `report_type`: required, currently supports `findings` and `scans`.
   - `last_updated_start_date`: required, beginning of date range for new or changed findings
   - `last_updated_end_date`: optional, end of date range for new or changed findings
   - `scan_type`: optional, one or more of 'Static Analysis', 'Dynamic Analysis', 'Manual', 'Software Composition Analysis', 'SCA'
-  - `finding_status`: optional, 'Open' or 'Closed'
-  - `passed_policy`: optional, boolean
+  - `finding_status`: optional, 'Open' or 'Closed'. Applies only to the `findings` report.
+  - `passed_policy`: optional, boolean. Applies only to the `findings` report.
   - `policy_sandbox`: optional, 'Policy' or 'Sandbox'
   - `application_id`: optional, application ID for which to return results
   - `rawjson`: optional, defaults to False. Returns full response if True, the GUID of the request if false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'veracode_api_py'
-version = '0.9.49'
+version = '0.9.50'
 authors = [ {name = "Tim Jarrett", email="tjarrett@veracode.com"} ]
 description = 'Python helper library for working with the Veracode APIs. Handles retries, pagination, and other features of the modern Veracode REST APIs.'
 readme = 'README.md'
@@ -22,4 +22,4 @@ dependencies = {file = ["requirements.txt"]}
 [project.urls]
 "Homepage" = "https://github.com/veracode/veracode-api-py"
 "Bug Tracker" = "https://github.com/veracode/veracode-api-py/issues"
-"Download" = "https://github.com/veracode/veracode-api-py/archive/v_0949.tar.gz"
+"Download" = "https://github.com/veracode/veracode-api-py/archive/v_0950.tar.gz"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
   name = 'veracode_api_py',         
   packages = ['veracode_api_py'],   
-  version = '0.9.49',      
+  version = '0.9.50',      
   license='MIT',        
   description = 'Python helper library for working with the Veracode APIs. Handles retries, pagination, and other features of the modern Veracode REST APIs.',   
   long_description = long_description,
@@ -15,7 +15,7 @@ setup(
   author = 'Tim Jarrett',                  
   author_email = 'tjarrett@veracode.com',      
   url = 'https://github.com/tjarrettveracode',   
-  download_url = 'https://github.com/veracode/veracode-api-py/archive/v_0949.tar.gz',    
+  download_url = 'https://github.com/veracode/veracode-api-py/archive/v_0950.tar.gz',    
   keywords = ['veracode', 'veracode-api'],   
   install_requires=[            
           'veracode-api-signing'

--- a/veracode_api_py/analytics.py
+++ b/veracode_api_py/analytics.py
@@ -55,13 +55,21 @@ class Analytics():
       else:
          return response['_embedded']['id'] #we will usually just need the guid so we can come back and fetch the report
 
-   def get(self,guid: UUID):
+   def get_findings(self, guid: UUID):
+      thestatus, thefindings = self.get(guid=guid,report_type='findings')
+      return thestatus, thefindings
+
+   def get_scans(self, guid: UUID):
+      thestatus, thescans = self.get(guid=guid,report_type='scans')
+      return thestatus, thescans
+   
+   def get(self,guid: UUID,report_type='findings'):
       # handle multiple scan types
       uri = "{}/{}".format(self.base_url,guid)
-      theresponse = APIHelper()._rest_paged_request(uri,"GET","findings",{},fullresponse=True)
+      theresponse = APIHelper()._rest_paged_request(uri,"GET",report_type,{},fullresponse=True)
       thestatus = theresponse.get('_embedded',{}).get('status','')
-      thefindings = theresponse.get('_embedded',{}).get('findings',{})
-      return thestatus, thefindings
+      thebody = theresponse.get('_embedded',{}).get(report_type,{})
+      return thestatus, thebody
 
    #helper methods
    def _case_insensitive_list_compare(self,input_list:list, target_list:list):


### PR DESCRIPTION
This PR adds the ability to use `Analytics().create_report` and `Analytics().get` with the [new Scans report type of the Veracode Reporting API](https://docs.veracode.com/updates/r/c_all_platform#new-scans-report-available-for-the-reporting-api-commercial-iconpng). It also adds dedicated methods for retrieving findings and scans reports.