### PR TITLE
Update applications.py for UUID bug

### DIFF
--- a/veracode_api_py/applications.py
+++ b/veracode_api_py/applications.py
@@ -94,7 +94,7 @@ class Applications():
             app_def.update({'teams': team_list})
 
         if business_unit != None:
-            bu = {'business_unit': {'guid': business_unit}}
+            bu = {'business_unit': {'guid': str(business_unit)}}
             app_def.update(bu)
 
         if (custom_fields != None):


### PR DESCRIPTION
# Bug Fix: Ensure UUIDs Are JSON Serializable in Application Creation/Update
## Summary

This PR fixes a bug in the Applications._create_or_update method where passing a UUID object directly into the payload results in a TypeError: Object of type UUID is not JSON serializable.
Root Cause

The json.dumps() call fails when it encounters a UUID object. Python's default JSON encoder does not support serializing UUIDs without conversion.
Fix

Wrapped UUID values with str() to ensure compatibility with json.dumps(). Specifically updated lines ≈88-90 

From:
```python
if business_unit != None:
    bu = {'business_unit': {'guid': business_unit}}
    app_def.update(bu)
```
To:
```python
if business_unit != None:
    bu = {'business_unit': {'guid': str(business_unit)}}
    app_def.update(bu)
```


## Context

The issue manifests when calling create() or update() with a UUID provided for business_unit, policy_guid, or similar fields. Without this fix, valid requests can raise runtime exceptions and block automation pipelines relying on these methods.
## Testing

    Manually tested with UUID inputs for business_unit and policy_guid.

    Confirmed that json.dumps() succeeds and payloads are correctly formatted.

    Applications were successfully created/updated via the API.

## Notes

There may be other locations in the codebase where UUIDs are passed into JSON payloads; recommend a broader audit to ensure consistent serialization.