### PR TITLE
Fix logical operators in identity.py

### DIFF
--- a/veracode_api_py/identity.py
+++ b/veracode_api_py/identity.py
@@ -95,11 +95,11 @@ class Users():
       if mfa:
          user_def.update({"pin_required":True})
 
-      if ipRestricted & len(allowedIpAddresses)>0:
+      if ipRestricted and len(allowedIpAddresses)>0:
          user_def.update({"ip_restricted":True})
          user_def.update({"allowed_ip_addresses": allowedIpAddresses})
 
-      if samlUser & len(samlSubject)>0:
+      if samlUser and len(samlSubject)>0:
          user_def.update({"saml_user":True})
          user_def.update({"saml_subject": samlSubject})
 


### PR DESCRIPTION
Fix logical operator in user creation conditionals

Replace bitwise AND (`&`) with logical AND (`and`) in user creation 
validation checks. The current implementation uses `&` which performs 
bitwise operations on boolean and integer operands, leading to incorrect 
behavior for certain input combinations.

Specifically, when creating a SAML user with an even-length subject or 
IP-restricted user with an even number of allowed IPs, the conditions 
incorrectly evaluate to False due to bitwise AND returning 0 for even 
values, preventing valid user configurations from being created.

Example - `if samlUser & len(samlSubject)>0:` with current buggy code:

Works (by accident or luck):
- samlUser=True, samlSubject="abc" (length 3, odd): `1 & 3 = 1 > 0` → True ✓
- samlUser=True, samlSubject="a" (length 1): `1 & 1 = 1 > 0` → True ✓
- samlUser=False, samlSubject="anything": `0 & len > 0` → False ✓

Breaks (for even-length subjects):
- samlUser=True, samlSubject="ab" (length 2, even): `1 & 2 = 0 > 0` → False ✗ (should be True)
- samlUser=True, samlSubject="abcd" (length 4, even): `1 & 4 = 0 > 0` → False ✗ (should be True)

Changes:
- Line 95: `if ipRestricted & len(allowedIpAddresses)>0:` → 
           `if ipRestricted and len(allowedIpAddresses) > 0:`
- Line 99: `if samlUser & len(samlSubject)>0:` → 
           `if samlUser and len(samlSubject) > 0:`

Fixes the logic to correctly check both conditions with proper precedence.